### PR TITLE
Closes #39 - By allowing a second click on image

### DIFF
--- a/src/js/Lightbox.js
+++ b/src/js/Lightbox.js
@@ -1,53 +1,3 @@
-import { isDOMElement, addClasses, removeClasses } from './util/dom';
-import throwIfMissing from './util/throwIfMissing';
-
-const LEFT_ARROW = 37;
-const RIGHT_ARROW = 39;
-
-// All officially-supported browsers have this, but it's easy to
-// account for, just in case.
-const HAS_ANIMATION = typeof document === 'undefined' ?
-  false :
-  'animation' in document.createElement('div').style;
-
-export default class Lightbox {
-  constructor(options = {}) {
-    let {
-      namespace = null,
-      parentEl = throwIfMissing(),
-      triggerEl = throwIfMissing(),
-      sourceAttribute = throwIfMissing(),
-      caption = null,
-      includeImgixJSClass = false,
-      _gallery = null,
-      _arrowNavigation = null,
-    } = options;
-
-    this.settings = { namespace, parentEl, triggerEl, sourceAttribute, caption, includeImgixJSClass, _gallery, _arrowNavigation };
-
-    if (!isDOMElement(this.settings.parentEl)) {
-      throw new TypeError('`new Lightbox` requires a DOM element passed as `parentEl`.');
-    }
-
-    this.currentTrigger = this.settings.triggerEl;
-
-    this.openClasses = this._buildClasses('open');
-    this.openingClasses = this._buildClasses('opening');
-    this.closingClasses = this._buildClasses('closing');
-
-    this.elementBuilt = false;
-  }
-
-  _buildClasses(suffix) {
-    let classes = [`lum-${suffix}`];
-
-    let ns = this.settings.namespace;
-    if (ns) {
-      classes.push(`${ns}-${suffix}`);
-    }
-
-    return classes;
-  }
 
   _buildElement() {
     this.el = document.createElement('div');
@@ -141,9 +91,14 @@ export default class Lightbox {
     }
 
     let loadingClasses = this._buildClasses('loading');
-    addClasses(this.el, loadingClasses);
+    
+    if(!this.hasBeenLoaded){
+      addClasses(this.el, loadingClasses);
+    }
+    
     this.imgEl.onload = () => {
       removeClasses(this.el, loadingClasses);
+      this.hasBeenLoaded = true;
     }
 
     this.imgEl.setAttribute('src', imageURL);

--- a/src/js/Lightbox.js
+++ b/src/js/Lightbox.js
@@ -1,3 +1,54 @@
+import { isDOMElement, addClasses, removeClasses } from './util/dom';
+import throwIfMissing from './util/throwIfMissing';
+
+const LEFT_ARROW = 37;
+const RIGHT_ARROW = 39;
+
+// All officially-supported browsers have this, but it's easy to
+// account for, just in case.
+const HAS_ANIMATION = typeof document === 'undefined' ?
+  false :
+  'animation' in document.createElement('div').style;
+
+export default class Lightbox {
+  constructor(options = {}) {
+    let {
+      namespace = null,
+      parentEl = throwIfMissing(),
+      triggerEl = throwIfMissing(),
+      sourceAttribute = throwIfMissing(),
+      caption = null,
+      includeImgixJSClass = false,
+      _gallery = null,
+      _arrowNavigation = null,
+    } = options;
+
+    this.settings = { namespace, parentEl, triggerEl, sourceAttribute, caption, includeImgixJSClass, _gallery, _arrowNavigation };
+
+    if (!isDOMElement(this.settings.parentEl)) {
+      throw new TypeError('`new Lightbox` requires a DOM element passed as `parentEl`.');
+    }
+
+    this.currentTrigger = this.settings.triggerEl;
+
+    this.openClasses = this._buildClasses('open');
+    this.openingClasses = this._buildClasses('opening');
+    this.closingClasses = this._buildClasses('closing');
+
+    this.hasBeenLoaded = false;
+    this.elementBuilt = false;
+  }
+
+  _buildClasses(suffix) {
+    let classes = [`lum-${suffix}`];
+
+    let ns = this.settings.namespace;
+    if (ns) {
+      classes.push(`${ns}-${suffix}`);
+    }
+
+    return classes;
+  }
 
   _buildElement() {
     this.el = document.createElement('div');


### PR DESCRIPTION
When the image is initially being fetched a nice loading screen is displayed. And once that image has been fully loaded, the loading screen is dismissed and the image is displayed.

```js
    let loadingClasses = this._buildClasses('loading');
    addClasses(this.el, loadingClasses);

    this.imgEl.onload = () => {
      removeClasses(this.el, loadingClasses);
    }

    this.imgEl.setAttribute('src', imageURL);
```

The problem is that if the user clicks on the image for a second time (after it is dismissed initially), it will add this loading class, but the event `load` will never be fired again.

This fix simply prevents the `loadingClasses` from being added to images that have already been loaded once.

Addresses issue #39 