### PR TITLE
Change package.json main to dist/luminous.min.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "luminous-lightbox",
   "version": "1.0.1",
   "description": "A simple, lightweight, no-dependencies JavaScript image lightbox.",
-  "main": "src/js/lum-require.js",
+  "main": "dist/luminous.min.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
To support easier consumption by bundlers (like Webpack), the source of this module shouldn't be the original `/src` but instead the generated output `/dist` which will help with this issue https://github.com/imgix/luminous/issues/43