### PR TITLE
chore: add Node.js 6, 8 and 10, remove Node.js 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - '6'
   - '8'
   - '10'
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-  - '4'
-
+  - '6'
+  - '8'
+  - '10'
 install:
   - npm install
 git:


### PR DESCRIPTION
Node.js 4 is EOL since last month.