### PR TITLE
feat(gallery): implement destroy() on LuminousGallery

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   },
   "homepage": "https://github.com/imgix/luminous#readme",
   "contributors": [
-    "Frederick Fogerty <frederick.fogerty@gmail.com> (https://github.com/frederickfogerty)"
+    "Frederick Fogerty <frederick.fogerty@gmail.com> (https://github.com/frederickfogerty)",
+    "Jakub Duras <jakub@duras.me> (https://duras.me)"
   ],
   "main": "lib/lum.js",
   "module": "es/lum.js",

--- a/src/js/LuminousGallery.js
+++ b/src/js/LuminousGallery.js
@@ -47,8 +47,6 @@ export default class LuminousGallery {
   boundMethod() {}
 
   destroy() {
-    this.luminousInstances.forEach(
-      (instance) => instance.destroy()
-    );
+    this.luminousInstances.forEach(instance => instance.destroy());
   }
 }

--- a/src/js/LuminousGallery.js
+++ b/src/js/LuminousGallery.js
@@ -46,5 +46,9 @@ export default class LuminousGallery {
 
   boundMethod() {}
 
-  destroy() {}
+  destroy() {
+    this.luminousInstances.forEach(
+      (instance) => instance.destroy()
+    );
+  }
 }


### PR DESCRIPTION
<!-- prettier-ignore-start -->
## Description

This PR implements the destroy() method that is [currently not implemented on the LuminousGallery](https://github.com/imgix/luminous/blob/8e6be3c5ed610487fd6175f1db4adf1f19fda5c3/src/js/LuminousGallery.js#L49) by destroying all instances.

Doesn't update README or tests since there is no mention of methods in the README and no tests for the gallery.

## Checklist

### New Feature

- [ ] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
- [x] Run unit tests to ensure all existing tests are still passing
- [ ] Add new passing unit tests to cover the code introduced by your PR
- [ ] Update the readme
- [ ] Add some [steps](#steps-to-test) so we can test your cool new feature!
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `feat(<area>): added new way to do this cool thing #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!
<!-- prettier-ignore-end -->
