### PR TITLE
fix: update closure file test to include more src files

### DIFF
--- a/config/karma/karma.config.js
+++ b/config/karma/karma.config.js
@@ -17,18 +17,9 @@ const webpackConfigAugmented = {
 
 const baseConfig = {
   frameworks: ["jasmine"],
-  files: [
-    {
-      pattern: "../../src/**/*.js",
-      included: false,
-      served: false,
-      watched: false
-    },
-    { pattern: "../../test/**/test*.js", watched: false }
-  ],
+  files: ["../../tests.webpack.js"],
   preprocessors: {
-    "../../src/**/*.js": ["webpack"],
-    "../../test/**/*.js": ["webpack"]
+    "../../tests.webpack.js": "webpack"
   },
   webpack: webpackConfigAugmented,
   webpackMiddleware: {

--- a/tests.webpack.js
+++ b/tests.webpack.js
@@ -1,0 +1,2 @@
+var context = require.context("./test", true, /\.js$/);
+context.keys().forEach(context);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,7 @@ function buildWithEnv(mode, outputFile) {
           compilation_level: "ADVANCED",
           create_source_map: true
         },
-        test: /src\/js\/\.*\.js($|\?)/,
+        test: /^(?!.*tests\.webpack).*$/,
         concurrency: 3
       })
     ]


### PR DESCRIPTION

## Description

This PR updates the webpack and closure config to ensure that all src files are included. The closure plugin we use has a test flag that didn't work initially as I thought, so after investigating this I was able to fix it. As a side-effect of this update, the bundle size is even smaller at 8KB, an improvement of 43% over the original bundle size.

### Bug Fix

- [x] All existing unit tests are still passing (if applicable)
- [N/A] Add new passing unit tests to cover the code introduced by your PR
- [N/A] Update the readme
- [N/A] Update or add any necessary API documentation
- [x] Add some [steps](#steps-to-test) so we can test your bug fix
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `fix(<area>): fixed bug #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

Steps:

1.  Check that CI passes