### PR TITLE
fix: export public API

### DIFF
--- a/src/js/Luminous.js
+++ b/src/js/Luminous.js
@@ -183,3 +183,7 @@ export default class Luminous {
     this.lightbox.destroy();
   }
 }
+
+Luminous.prototype["open"] = Luminous.prototype.open;
+Luminous.prototype["close"] = Luminous.prototype.close;
+Luminous.prototype["destroy"] = Luminous.prototype.destroy;

--- a/src/js/LuminousGallery.js
+++ b/src/js/LuminousGallery.js
@@ -3,7 +3,6 @@ import Luminous from "./Luminous";
 
 export default class LuminousGallery {
   constructor(triggers, options = {}, luminousOpts = {}) {
-    this.boundMethod = this.boundMethod.bind(this);
     let { arrowNavigation = true } = options;
 
     this.settings = { arrowNavigation };
@@ -43,8 +42,6 @@ export default class LuminousGallery {
       ? this.triggers[this.triggers.length - 1]
       : this.triggers[prevTriggerIndex];
   }
-
-  boundMethod() {}
 
   destroy() {
     this.luminousInstances.forEach(instance => instance.destroy());

--- a/src/js/LuminousGallery.js
+++ b/src/js/LuminousGallery.js
@@ -47,3 +47,5 @@ export default class LuminousGallery {
     this.luminousInstances.forEach(instance => instance.destroy());
   }
 }
+
+LuminousGallery.prototype["destroy"] = LuminousGallery.prototype.destroy;


### PR DESCRIPTION
## Description

This PR uses [the approach preferred by the Closure docs](https://developers.google.com/closure/compiler/docs/api-tutorial3#export) to export the public API of the Luminous and LuminousGallery classes. This has to happen because Closure rewrites the names of the class methods, which prevents third-parties from calling methods by their proper names.

### Bug Fix

- [x] All existing unit tests are still passing (if applicable)
- [N/A] Add new passing unit tests to cover the code introduced by your PR
- [N/A] Update the readme
- [N/A] Update or add any necessary API documentation
- [x] Add some [steps](#steps-to-test) so we can test your bug fix
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `fix(<area>): fixed bug #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

Steps:

1.  Clone this PR, `npm install`
2. 	Run `npm run build:watch`
2.	Play around with drift in `index.html`. `console.log(new Luminous(...))` should show that everything is exported on the prototype.

