### PR TITLE
feat: add shadow dom support for base styles

### DIFF
--- a/src/js/Luminous.js
+++ b/src/js/Luminous.js
@@ -21,7 +21,7 @@ export default class Luminous {
     }
 
     let rootNode = document;
-    if ('getRootNode' in this.trigger) {
+    if ("getRootNode" in this.trigger) {
       rootNode = this.trigger.getRootNode();
     }
     // Prefix for generated element class names (e.g. `my-ns` will

--- a/src/js/Luminous.js
+++ b/src/js/Luminous.js
@@ -20,6 +20,10 @@ export default class Luminous {
       );
     }
 
+    let rootNode = document;
+    if ('getRootNode' in this.trigger) {
+      rootNode = this.trigger.getRootNode();
+    }
     // Prefix for generated element class names (e.g. `my-ns` will
     // result in classes such as `my-ns-lightbox`. Default `lum-`
     // prefixed classes will always be added as well.
@@ -73,7 +77,7 @@ export default class Luminous {
     };
 
     if (this.settings.injectBaseStyles) {
-      injectBaseStylesheet();
+      injectBaseStylesheet(rootNode);
     }
 
     this._buildLightbox();

--- a/src/js/injectBaseStylesheet.js
+++ b/src/js/injectBaseStylesheet.js
@@ -49,8 +49,12 @@
 
 const RULES = `@keyframes lum-noop{0%{zoom:1}}.lum-lightbox{position:fixed;display:none;top:0;right:0;bottom:0;left:0}.lum-lightbox.lum-open{display:block}.lum-lightbox.lum-closing,.lum-lightbox.lum-opening{animation:lum-noop 1ms}.lum-lightbox-inner{position:absolute;top:0;right:0;bottom:0;left:0;overflow:hidden}.lum-lightbox-loader{display:none}.lum-lightbox-inner img{max-width:100%;max-height:100%}.lum-lightbox-image-wrapper{vertical-align:middle;display:table-cell;text-align:center}`;
 
-export default function injectBaseStylesheet() {
-  if (document.querySelector(".lum-base-styles")) {
+export default function injectBaseStylesheet(node) {
+  if (!node || node === document) {
+    node = document.head;
+  }
+
+  if (node.querySelector(".lum-base-styles")) {
     return;
   }
 
@@ -60,6 +64,5 @@ export default function injectBaseStylesheet() {
 
   styleEl.appendChild(document.createTextNode(RULES));
 
-  const head = document.head;
-  head.insertBefore(styleEl, head.firstChild);
+  node.insertBefore(styleEl, node.firstChild);
 }

--- a/test/testLuminous.js
+++ b/test/testLuminous.js
@@ -78,7 +78,7 @@ describe("Core", () => {
     document.body.appendChild(container);
 
     const lum = new Luminous(anchor);
-    const styles = container.shadowRoot.querySelector('style.lum-base-styles');
+    const styles = container.shadowRoot.querySelector("style.lum-base-styles");
     expect(styles).not.toBe(null);
   });
 });

--- a/test/testLuminous.js
+++ b/test/testLuminous.js
@@ -68,6 +68,10 @@ describe("Core", () => {
   });
 
   it("injects styles into shadow root if parented by one", () => {
+    // TODO (43081j): remove when firefox ships with shadow DOM
+    if (typeof ShadowRoot === "undefined") {
+      return;
+    }
     const container = document.createElement("div");
     container.attachShadow({ mode: "open" });
     const anchor = document.createElement("a");

--- a/test/testLuminous.js
+++ b/test/testLuminous.js
@@ -66,6 +66,21 @@ describe("Core", () => {
     lum.close();
     expect(called).toBe(true);
   });
+
+  it("injects styles into shadow root if parented by one", () => {
+    const container = document.createElement("div");
+    container.attachShadow({ mode: "open" });
+    const anchor = document.createElement("a");
+    anchor.href = "https://example.com/image.png";
+    anchor.classList.add("test-shadow-anchor");
+
+    container.shadowRoot.appendChild(anchor);
+    document.body.appendChild(container);
+
+    const lum = new Luminous(anchor);
+    const styles = container.shadowRoot.querySelector('style.lum-base-styles');
+    expect(styles).not.toBe(null);
+  });
 });
 
 describe("Configuration", () => {


### PR DESCRIPTION
## Description

The point of this is to account for luminous being used in shadow roots.

By using `getRootNode` (if supported), we can get to the `#shadow-root` rather than `document`. If we're not in one, we get `document`.

### New Feature

- [ ] If this is a big feature with breaking changes, consider [opening an issue][issues] to discuss first. This is completely up to you, but please keep in mind that your PR might not be accepted.
- [x] Run unit tests to ensure all existing tests are still passing
- [x] Add new passing unit tests to cover the code introduced by your PR
- [ ] Update the readme
- [x] Add some [steps](#steps-to-test) so we can test your cool new feature!
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `feat(<area>): added new way to do this cool thing #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

Create an element just like in the added test. Its as simple as your target element for luminous being a child of a shadow root.