### PR TITLE
fix: support shadow roots for lightboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,10 @@ var options = {
   closeOnScroll: false,
   // Disable close button
   showCloseButton: false,
+  // A node append the lightbox element to.
+  appendToNode: document.body,
   // A selector defining what to append the lightbox element to.
-  appendToSelector: "body",
+  appendToSelector: null,
   // If present (and a function), this will be called
   // whenever the lightbox is opened.
   onOpen: null,

--- a/README.md
+++ b/README.md
@@ -112,9 +112,10 @@ var options = {
   closeOnScroll: false,
   // Disable close button
   showCloseButton: false,
-  // A node append the lightbox element to.
+  // A node to append the lightbox element to.
   appendToNode: document.body,
   // A selector defining what to append the lightbox element to.
+  // This will take precedence over `appendToNode`.
   appendToSelector: null,
   // If present (and a function), this will be called
   // whenever the lightbox is opened.

--- a/src/js/Luminous.js
+++ b/src/js/Luminous.js
@@ -83,8 +83,13 @@ export default class Luminous {
       _arrowNavigation
     };
 
+    let injectionRoot = document.body;
+    if (appendToNode && "getRootNode" in appendToNode) {
+      injectionRoot = appendToNode.getRootNode();
+    }
+
     if (this.settings.injectBaseStyles) {
-      injectBaseStylesheet(rootNode);
+      injectBaseStylesheet(injectionRoot);
     }
 
     this._buildLightbox();

--- a/src/js/Luminous.js
+++ b/src/js/Luminous.js
@@ -43,7 +43,10 @@ export default class Luminous {
     const closeButtonEnabled =
       options["showCloseButton"] != null ? options["showCloseButton"] : true;
     // A selector defining what to append the lightbox element to.
-    const appendToSelector = options["appendToSelector"] || "body";
+    const appendToNode =
+      options["appendToNode"] ||
+      (rootNode === document ? document.body : rootNode);
+    const appendToSelector = options["appendToSelector"] || null;
     // If present (and a function), this will be called
     // whenever the lightbox is opened.
     const onOpen = options["onOpen"] || null;
@@ -70,6 +73,7 @@ export default class Luminous {
       closeWithEscape,
       closeOnScroll,
       closeButtonEnabled,
+      appendToNode,
       appendToSelector,
       onOpen,
       onClose,
@@ -122,9 +126,15 @@ export default class Luminous {
   }
 
   _buildLightbox() {
+    let parentEl = this.settings.appendToNode;
+
+    if (this.settings.appendToSelector) {
+      parentEl = document.querySelector(this.settings.appendToSelector);
+    }
+
     this.lightbox = new Lightbox({
       namespace: this.settings.namespace,
-      parentEl: document.querySelector(this.settings.appendToSelector),
+      parentEl: parentEl,
       triggerEl: this.trigger,
       sourceAttribute: this.settings.sourceAttribute,
       caption: this.settings.caption,

--- a/src/js/Luminous.js
+++ b/src/js/Luminous.js
@@ -42,10 +42,10 @@ export default class Luminous {
     const closeOnScroll = options["closeOnScroll"] || false;
     const closeButtonEnabled =
       options["showCloseButton"] != null ? options["showCloseButton"] : true;
-    // A selector defining what to append the lightbox element to.
     const appendToNode =
       options["appendToNode"] ||
       (rootNode === document ? document.body : rootNode);
+    // A selector defining what to append the lightbox element to.
     const appendToSelector = options["appendToSelector"] || null;
     // If present (and a function), this will be called
     // whenever the lightbox is opened.

--- a/src/js/util/dom.js
+++ b/src/js/util/dom.js
@@ -1,8 +1,12 @@
 // This is not really a perfect check, but works fine.
 // From http://stackoverflow.com/questions/384286
 const HAS_DOM_2 = typeof HTMLElement === "object";
+const HAS_SHADOW = typeof ShadowRoot !== "undefined";
 
 export function isDOMElement(obj) {
+  if (HAS_SHADOW && obj instanceof ShadowRoot) {
+    return true;
+  }
   return HAS_DOM_2
     ? obj instanceof HTMLElement
     : obj &&

--- a/test/testLuminous.js
+++ b/test/testLuminous.js
@@ -85,6 +85,27 @@ describe("Core", () => {
     const styles = container.shadowRoot.querySelector("style.lum-base-styles");
     expect(styles).not.toBe(null);
   });
+
+  it("appends to shadow dom if parented by one", () => {
+    // TODO (43081j): remove when firefox ships with shadow DOM
+    if (typeof ShadowRoot === "undefined") {
+      return;
+    }
+    const container = document.createElement("div");
+    container.attachShadow({ mode: "open" });
+    const anchor = document.createElement("a");
+    anchor.href = "https://example.com/image.png";
+    anchor.classList.add("test-shadow-anchor");
+
+    container.shadowRoot.appendChild(anchor);
+    document.body.appendChild(container);
+
+    const lum = new Luminous(anchor);
+    anchor.click();
+
+    const lightbox = container.shadowRoot.querySelector(".lum-lightbox");
+    expect(lightbox).not.toBe(null);
+  });
 });
 
 describe("Configuration", () => {


### PR DESCRIPTION
## Description

My recent PR fixed styles being injected into shadow roots, but I had overlooked the fact that the lightbox is still appended to the document.

This means the styles don't get used as the lightbox is in the wrong root.

This fix introduces:

* `appendToNode` option which allows you to set the parent as a node
* if in a shadow root, `appendToNode` defaults to the shadow root
* if not in a shadow root, `appendToNode` defaults to `body`
* `appendToSelector` defaults to `null`
* `appendToSelector` takes precedence over `appendToNode`
* Use the `parentEl` root document for style injection rather than the trigger's root document

### Bug Fix

- [x] All existing unit tests are still passing (if applicable)
- [x] Add new passing unit tests to cover the code introduced by your PR
- [x] Update the readme
- [ ] Update or add any necessary API documentation
- [x] Add some [steps](#steps-to-test) so we can test your bug fix
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `fix(<area>): fixed bug #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

## Steps to Test

Create a new luminous instance on an element in a shadow root.