### PR TITLE
chore(travis): only run build check on master and release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - '8'
-  - '10'
+  - "8"
+  - "10"
 install:
   - npm install
 git:
@@ -21,3 +21,8 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.8
+
+branches:
+  only:
+    - master
+    - /release.*/


### PR DESCRIPTION
## Description

Currently Travis runs two builds per PR. One of these is a branch build, one of these is a PR build. This slows down PR times.

This PR configures Travis to only run branch builds on the master branch.