### PR TITLE
fix: improved overriding default settings (#105)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "homepage": "https://github.com/imgix/luminous#readme",
   "contributors": [
     "Frederick Fogerty <frederick.fogerty@gmail.com> (https://github.com/frederickfogerty)",
-    "Jakub Duras <jakub@duras.me> (https://duras.me)"
+    "Jakub Duras <jakub@duras.me> (https://duras.me)",
+    "Andrej Cremoznik <andrej@cremoznik.si> (https://keybase.io/andrejcremoznik)"
   ],
   "main": "lib/lum.js",
   "module": "es/lum.js",

--- a/src/js/Luminous.js
+++ b/src/js/Luminous.js
@@ -32,68 +32,56 @@ export default class Luminous {
     if ("getRootNode" in this.trigger) {
       rootNode = this.trigger.getRootNode();
     }
-    // Prefix for generated element class names (e.g. `my-ns` will
-    // result in classes such as `my-ns-lightbox`. Default `lum-`
-    // prefixed classes will always be added as well.
-    const namespace = options["namespace"] || null;
-    // Which attribute to pull the lightbox image source from.
-    const sourceAttribute = options["sourceAttribute"] || "href";
-    // Captions can be a literal string, or a function that receives the Luminous instance's trigger element as an argument and returns a string. Supports HTML, so use caution when dealing with user input.
-    const caption = options["caption"] || null;
-    // The event to listen to on the _trigger_ element: triggers opening.
-    const openTrigger = options["openTrigger"] || "click";
-    // The event to listen to on the _lightbox_ element: triggers closing.
-    const closeTrigger = options["closeTrigger"] || "click";
-    // Allow closing by pressing escape.
-    const closeWithEscape = options["closeWithEscape"] || true;
-    // Automatically close when the page is scrolled.
-    const closeOnScroll = options["closeOnScroll"] || false;
-    const closeButtonEnabled =
-      options["showCloseButton"] != null ? options["showCloseButton"] : true;
-    const appendToNode =
-      options["appendToNode"] ||
-      (rootNode === document ? document.body : rootNode);
-    // A selector defining what to append the lightbox element to.
-    const appendToSelector = options["appendToSelector"] || null;
-    // If present (and a function), this will be called
-    // whenever the lightbox is opened.
-    const onOpen = options["onOpen"] || null;
-    // If present (and a function), this will be called
-    // whenever the lightbox is closed.
-    const onClose = options["onClose"] || null;
-    // When true, adds the `imgix-fluid` class to the `img`
-    // inside the lightbox. See https://github.com/imgix/imgix.js
-    // for more information.
-    const includeImgixJSClass = options["includeImgixJSClass"] || false;
-    // Add base styles to the page. See the "Theming"
-    // section of README.md for more information.
-    const injectBaseStyles = options["injectBaseStyles"] || true;
-    // Internal use only!
-    const _gallery = options["_gallery"] || null;
-    const _arrowNavigation = options["_arrowNavigation"] || null;
 
-    this.settings = {
-      namespace,
-      sourceAttribute,
-      caption,
-      openTrigger,
-      closeTrigger,
-      closeWithEscape,
-      closeOnScroll,
-      closeButtonEnabled,
-      appendToNode,
-      appendToSelector,
-      onOpen,
-      onClose,
-      includeImgixJSClass,
-      injectBaseStyles,
-      _gallery,
-      _arrowNavigation
+    const DEFAULTS = {
+      // Prefix for generated element class names (e.g. `my-ns` will
+      // result in classes such as `my-ns-lightbox`. Default `lum-`
+      // prefixed classes will always be added as well.
+      namespace: null,
+      // Which attribute to pull the lightbox image source from.
+      sourceAttribute: "href",
+      // Captions can be a literal string, or a function that receives the Luminous
+      // instance's trigger element as an argument and returns a string. Supports
+      // HTML, so use caution when dealing with user input.
+      caption: null,
+      // The event to listen to on the _trigger_ element: triggers opening.
+      openTrigger: "click",
+      // The event to listen to on the _lightbox_ element: triggers closing.
+      closeTrigger: "click",
+      // Allow closing by pressing escape.
+      closeWithEscape: true,
+      // Automatically close when the page is scrolled.
+      closeOnScroll: false,
+      closeButtonEnabled: true,
+      appendToNode: rootNode === document ? document.body : rootNode,
+      // A selector defining what to append the lightbox element to.
+      appendToSelector: null,
+      // If present (and a function), this will be called
+      // whenever the lightbox is opened.
+      onOpen: null,
+      // If present (and a function), this will be called
+      // whenever the lightbox is closed.
+      onClose: null,
+      // When true, adds the `imgix-fluid` class to the `img`
+      // inside the lightbox. See https://github.com/imgix/imgix.js
+      // for more information.
+      includeImgixJSClass: false,
+      // Add base styles to the page. See the "Theming"
+      // section of README.md for more information.
+      injectBaseStyles: true,
+      // Internal use only!
+      _gallery: null,
+      _arrowNavigation: null
     };
 
+    this.settings = Object.assign({}, DEFAULTS, options);
+
     let injectionRoot = document.body;
-    if (appendToNode && "getRootNode" in appendToNode) {
-      injectionRoot = appendToNode.getRootNode();
+    if (
+      this.settings.appendToNode &&
+      "getRootNode" in this.settings.appendToNode
+    ) {
+      injectionRoot = this.settings.appendToNode.getRootNode();
     }
 
     if (this.settings.injectBaseStyles) {

--- a/test/testLuminous.js
+++ b/test/testLuminous.js
@@ -139,43 +139,19 @@ describe("Configuration", () => {
 
   it("passes settings to Lightbox", () => {
     const anchor = document.querySelector(".test-anchor");
-    const settingsToMap = {
+    const settings = {
       namespace: "custom",
       sourceAttribute: "not-href",
       caption: "custom",
       includeImgixJSClass: true,
-      showCloseButton: {
-        value: false,
-        lightboxKey: "closeButtonEnabled"
-      }
+      closeButtonEnabled: false
     };
-    const isObject = v => typeof v === "object" && v != null;
-    const clientSettings = Object.keys(settingsToMap).reduce((p, key) => {
-      const valuePrimitiveOrObject = settingsToMap[key];
-      p[key] = isObject(valuePrimitiveOrObject)
-        ? valuePrimitiveOrObject.value
-        : valuePrimitiveOrObject;
-      return p;
-    }, {});
 
-    const lum = new Luminous(anchor, clientSettings);
+    const lum = new Luminous(anchor, settings);
 
-    Object.keys(settingsToMap).forEach(settingKey => {
-      const valuePrimitiveOrObject = settingsToMap[settingKey];
-      let expectedKey;
-      let expectedValue;
-      if (isObject(valuePrimitiveOrObject)) {
-        const valueConfig = valuePrimitiveOrObject;
-        expectedKey = valueConfig.lightboxKey || settingKey;
-        expectedValue =
-          "lightboxValue" in valueConfig
-            ? valueConfig.lightboxValue
-            : valueConfig.value;
-      } else {
-        expectedKey = settingKey;
-        expectedValue = valuePrimitiveOrObject;
-      }
-      expect(lum.lightbox.settings[expectedKey]).toBe(expectedValue);
+    Object.keys(settings).forEach(key => {
+      const value = settings[key];
+      expect(lum.lightbox.settings[key]).toBe(value);
     });
   });
 });


### PR DESCRIPTION
## Description

Refactor how user supplied options override defaults. This fixes bug #105 .

#105 could be fixed inline but I found that to be ugly. This approach by merging objects looks and works better.

## Checklist

### Bug Fix

- [ ] All existing unit tests are still passing (if applicable)
- [x] Add some [steps](#steps-to-test) so we can test your bug fix
- [x] The PR title is in the [conventional commit](#conventional-commit-spec) format: e.g. `fix(<area>): fixed bug #issue-number`
- [x] Add your info to the [contributors](#packagejson-contributors) array in package.json!

**I could not run tests locally.** I use linux & node v10.12.0 and I'm getting `DeprecationWarning: Tapable.plugin is deprecated.` I'm not going to debug the build tool chain.

I could run `build:js:lib:es` to get a working build that I could use in my project to confirm it's working.

## Steps to Test

Related issue: #105 

Code:

```js
new Luminous(node, { injectBaseStyles: false })
```

Steps:

1. Init Luminous with some custom options
2. Confirm custom options work
3. `injectBaseStyles: false` didn't work before, it does now