### PR TITLE
fix: allow "closeWithEscape" and "injectBaseStyles" to be overriden when initializing

### DIFF
--- a/src/js/Luminous.js
+++ b/src/js/Luminous.js
@@ -45,7 +45,7 @@ export default class Luminous {
     // The event to listen to on the _lightbox_ element: triggers closing.
     const closeTrigger = options["closeTrigger"] || "click";
     // Allow closing by pressing escape.
-    const closeWithEscape = options["closeWithEscape"] || true;
+    const closeWithEscape = "closeWithEscape" in options ? !!options["closeWithEscape"] : true;
     // Automatically close when the page is scrolled.
     const closeOnScroll = options["closeOnScroll"] || false;
     const closeButtonEnabled =
@@ -67,7 +67,7 @@ export default class Luminous {
     const includeImgixJSClass = options["includeImgixJSClass"] || false;
     // Add base styles to the page. See the "Theming"
     // section of README.md for more information.
-    const injectBaseStyles = options["injectBaseStyles"] || true;
+    const injectBaseStyles = "injectBaseStyles" in options ? !!options["injectBaseStyles"] : true;
     // Internal use only!
     const _gallery = options["_gallery"] || null;
     const _arrowNavigation = options["_arrowNavigation"] || null;

--- a/test/testLuminous.js
+++ b/test/testLuminous.js
@@ -137,6 +137,14 @@ describe("Configuration", () => {
     expect(lum.settings.openTrigger).toBe("click");
   });
 
+  it("allows truthy defaults to be overridden  ", () => {
+    const anchor = document.querySelector(".test-anchor");
+    const lum = new Luminous(anchor, { closeWithEscape: false, injectBaseStyles: false });
+
+    expect(lum.settings.closeWithEscape).toBe(false);
+    expect(lum.settings.injectBaseStyles).toBe(false);
+  });
+
   it("passes settings to Lightbox", () => {
     const anchor = document.querySelector(".test-anchor");
     const settingsToMap = {


### PR DESCRIPTION
This PR corrects logic that prevented users from overriding the default value (`true`) of the `closeWithEscape` and `injectBaseStyles` configs when instantiating a new `Luminous` object.

Fixes #478 #105 