### PR TITLE
ci: update supported node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - "8"
-  - "10"
+  - stable
 install:
   - npm install
 git:


### PR DESCRIPTION
Adds [currently supported](https://nodejs.org/en/about/releases/) LTS node versions to CI.

TODO: remove EOL'd versions in a future major release