### PR TITLE
fix: bring package version back in sync

### DIFF
--- a/src/js/Luminous.js
+++ b/src/js/Luminous.js
@@ -1,3 +1,4 @@
+import { version } from "../../package.json";
 import { isDOMElement } from "./util/dom";
 import injectBaseStylesheet from "./injectBaseStylesheet";
 import Lightbox from "./Lightbox";
@@ -12,7 +13,7 @@ export default class Luminous {
    * @param {Object=} options Luminous options
    */
   constructor(trigger, options = {}) {
-    this.VERSION = "2.3.3";
+    this.VERSION = version;
     this.destroy = this.destroy.bind(this);
     this.open = this.open.bind(this);
     this.close = this.close.bind(this);
@@ -45,7 +46,8 @@ export default class Luminous {
     // The event to listen to on the _lightbox_ element: triggers closing.
     const closeTrigger = options["closeTrigger"] || "click";
     // Allow closing by pressing escape.
-    const closeWithEscape = "closeWithEscape" in options ? !!options["closeWithEscape"] : true;
+    const closeWithEscape =
+      "closeWithEscape" in options ? !!options["closeWithEscape"] : true;
     // Automatically close when the page is scrolled.
     const closeOnScroll = options["closeOnScroll"] || false;
     const closeButtonEnabled =
@@ -67,7 +69,8 @@ export default class Luminous {
     const includeImgixJSClass = options["includeImgixJSClass"] || false;
     // Add base styles to the page. See the "Theming"
     // section of README.md for more information.
-    const injectBaseStyles = "injectBaseStyles" in options ? !!options["injectBaseStyles"] : true;
+    const injectBaseStyles =
+      "injectBaseStyles" in options ? !!options["injectBaseStyles"] : true;
     // Internal use only!
     const _gallery = options["_gallery"] || null;
     const _arrowNavigation = options["_arrowNavigation"] || null;
@@ -88,7 +91,7 @@ export default class Luminous {
       includeImgixJSClass,
       injectBaseStyles,
       _gallery,
-      _arrowNavigation
+      _arrowNavigation,
     };
 
     let injectionRoot = document.body;
@@ -171,7 +174,7 @@ export default class Luminous {
       _gallery: this.settings._gallery,
       _arrowNavigation: this.settings._arrowNavigation,
       closeTrigger: this.settings.closeTrigger,
-      onClose: this.close
+      onClose: this.close,
     });
   }
 


### PR DESCRIPTION
This commit has the library read the version number from the `package.json` reducing the number of places where this needs to be changed by hand upon cutting a release. Note, the `bower.json` will still need to be updated by hand.

This change specifically has semantic-release support in mind.

This commit also applies some eslint rules to the file.