### PR TITLE
chore: hard code version number in `src/Luminous.js`

### DIFF
--- a/src/js/Luminous.js
+++ b/src/js/Luminous.js
@@ -1,4 +1,3 @@
-import { version } from "../../package.json";
 import { isDOMElement } from "./util/dom";
 import injectBaseStylesheet from "./injectBaseStylesheet";
 import Lightbox from "./Lightbox";
@@ -13,7 +12,7 @@ export default class Luminous {
    * @param {Object=} options Luminous options
    */
   constructor(trigger, options = {}) {
-    this.VERSION = version;
+    this.VERSION = "2.3.4";
     this.destroy = this.destroy.bind(this);
     this.open = this.open.bind(this);
     this.close = this.close.bind(this);


### PR DESCRIPTION
This commit undoes the change where the version was being read from the
package.json and hard codes the version number to the correct number.
Semantic release will take care of bumping this for is future so
there's no need to read it from the package.json.

Not doing this meant that semantic-release would not properly detect
changes to the version numbers. IE, it could not find the text it needed
to replace for the version numbers. This makes sense since, afaik, it
does not evaluate the code when it searches for matching text. So,
`this.version = VERSION` for example would mean it'd be trying to
bump a the version number of `VERSION`, not whatever that variable
actually evaluates to.