### PR TITLE
build: enable semantic release on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ deploy:
   script:
     - npx semantic-release
   on:
-    branch: next
+    all_branches: true

--- a/package.json
+++ b/package.json
@@ -113,13 +113,13 @@
           "replacements": [
             {
               "files": [
-                "src/Luminous.js"
+                "src/js/Luminous.js"
               ],
-              "from": "this.VERSION = '.*'",
-              "to": "this.VERSION = '${nextRelease.version}'",
+              "from": "this.VERSION = \".*\"",
+              "to": "this.VERSION = \"${nextRelease.version}\"",
               "results": [
                 {
-                  "file": "src/Luminous.js",
+                  "file": "src/js/Luminous.js",
                   "hasChanged": true,
                   "numMatches": 1,
                   "numReplacements": 1


### PR DESCRIPTION
This commit changes the travis release script to release on all
branches. It also changes the replace plugin to a regex instead of a
string, which is more reliable and matches the release plugin's docs
more closely. It also fixes an issue where the replacement files
directory was missing the `js` subdirectory.