### PR TITLE
chore: use openssl legacy provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
-node_js:
-  - stable
+jobs:
+  include:
+  - node: lts/*
+  - node: stable
+    env: NODE_OPTIONS=--openssl-legacy-provider
 install:
   - npm install
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 jobs:
   include:
-  - node: lts/*
   - node: stable
     env: NODE_OPTIONS=--openssl-legacy-provider
 install:


### PR DESCRIPTION
On node/stable builds, the following error occurs:

[karma-server]: UnhandledRejection: error:0308010C:digital envelope routines::unsupported

Currently, the most accepted answer (https://github.com/webpack/webpack/issues/14532#issuecomment-947012063) to fix this is to use the legacy version of openssl for non-LTS node versions.
