### PR TITLE
build(travis): pin node v17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 jobs:
   include:
-  - node: stable
+  - node: 17
     env: NODE_OPTIONS=--openssl-legacy-provider
 install:
   - npm install


### PR DESCRIPTION
This commit fixes an issue where travis node lts was set to 18. This caused build errors on CI.