### PR TITLE
chore(dev-deps): update jasmine to v4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "eslint-config-google": "0.14.0",
         "eslint-config-prettier": "8.3.0",
         "google-closure-compiler-js": "20200719.0.0",
-        "jasmine-core": "3.10.1",
+        "jasmine-core": "4.4.0",
         "karma": "6.4.1",
         "karma-chrome-launcher": "3.1.1",
         "karma-firefox-launcher": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint-config-google": "0.14.0",
     "eslint-config-prettier": "8.3.0",
     "google-closure-compiler-js": "20200719.0.0",
-    "jasmine-core": "3.10.1",
+    "jasmine-core": "4.4.0",
     "karma": "6.4.1",
     "karma-chrome-launcher": "3.1.1",
     "karma-firefox-launcher": "2.1.2",


### PR DESCRIPTION
One of the renovate PRs merged in an outdated version of jasmine by mistake. This PR updates the jasmine dev-dep to the correct version.