### PR TITLE
ci(node): support lts and current

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     parameters:
       version:
-        default: "stable"
+        default: "current"
         description: Node.JS version to install
         type: string
     docker:
@@ -18,12 +18,7 @@ jobs:
       - checkout
       - browser-tools/install-browser-tools:
           install-geckodriver: false
-      - when:
-          condition:
-            equal: ["17.9", <<parameters.version>>]
-          steps:
-            # Prevents build error on stable node version
-            - run: echo 'export NODE_OPTIONS=--openssl-legacy-provider' >> $BASH_ENV
+      - run: echo 'export NODE_OPTIONS=--openssl-legacy-provider' >> $BASH_ENV
       - run: npm install
       - node/install-packages:
           pkg-manager: npm
@@ -50,7 +45,7 @@ workflows:
           matrix:
             parameters:
               version:
-                - "17.9"
+                - "current"
                 - "lts"
 
       - deploy:


### PR DESCRIPTION
Adds support for latest LTS and Current versions of Node, as well as unpinning Node 17.9.
